### PR TITLE
fix for errantly removing falsy values from payload

### DIFF
--- a/lib/payloadHelper.js
+++ b/lib/payloadHelper.js
@@ -55,6 +55,7 @@ function removePropsNotSet(payload, payloadDataPaths) {
 	payloadDataPaths.sort();
 	payloadDataPaths.forEach(function payloadDataPathsForEachCb(dataPath, idx) {
 		var objVal = objectPath(payload, dataPath);
+		if(~['boolean', 'number'].indexOf(typeof objVal)) objVal = true;
 		if(~deleteVals.indexOf(objVal)) objVal = false;
 		if(objVal && typeof objVal === 'object' && Object.keys(objVal).length === 0) objVal = false;
 		if(!objVal) {


### PR DESCRIPTION
This fix addresses boolean values of `false`and numeric values of `0` being improperly type coerced and evaluated as "unset" and therefore removed from payload.